### PR TITLE
Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,53 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        applies-to:
+          - version-updates
+          - security-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: npm
     directory: "/server"
     schedule:
       interval: "weekly"
+    groups:
+      security:
+        applies-to:
+          - security-updates
+        update-types:
+          - "minor"
+          - "patch"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: npm
     directory: "/webapp"
     schedule:
       interval: "weekly"
+    groups:
+      security:
+        applies-to:
+          - security-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # group all dev dependencies together regardless of versions
+      dev-dependencies:
+        patterns:
+          - "@babel*"
+          - "@types*"
+          - "babel*"
+          - "*webpack*"
+          - "*loader*"
+      # group all other minor and patches
+      minor-and-patches:
+        applies-to:
+          - version-updates
+        update-types:
+          - "minor"
+          - "patch"
+


### PR DESCRIPTION
Root:
* will separate out major versions
* will group all minor and patch

Server:
* will separate out major versions
* separate security updates
* separate version updates

Webapp:
* will separate major versions for dependencies
* will group all dev dependencies together regardless of version
  * this is because it looks like webpack, babel, and their respective loaders will likely receive upgrades together
* separate security updates
* group all other updates based on minor and patch